### PR TITLE
Get rid of setwd() bits

### DIFF
--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -108,11 +108,11 @@ bookdown_to_leanpub = function(path = ".",
   rmd_regex = "[.][R|r]md$"
 
   path = bookdown_path(path)
-  owd = getwd()
-  setwd(path)
-  on.exit({
-    setwd(owd)
-  })
+  #owd = getwd()
+  #setwd(path)
+  #on.exit({
+  #  setwd(owd)
+  #})
   rmd_files = bookdown_rmd_files(path = path)
   if (render) {
     if (verbose) {
@@ -233,11 +233,11 @@ bookdown_to_book_txt = function(
   rm(list = c("full_file", "index"))
 
   path = bookdown_path(path)
-  owd = getwd()
-  setwd(path)
-  on.exit({
-    setwd(owd)
-  })
+  #owd = getwd()
+  #setwd(path)
+  #on.exit({
+  # setwd(owd)
+  #})
   rmd_regex = "[.][R|r]md$"
   rmd_files = bookdown_rmd_files(path = path)
   md_files = sub(rmd_regex, ".md", rmd_files, ignore.case = TRUE)

--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -108,11 +108,7 @@ bookdown_to_leanpub = function(path = ".",
   rmd_regex = "[.][R|r]md$"
 
   path = bookdown_path(path)
-  #owd = getwd()
-  #setwd(path)
-  #on.exit({
-  #  setwd(owd)
-  #})
+
   rmd_files = bookdown_rmd_files(path = path)
   if (render) {
     if (verbose) {
@@ -233,11 +229,7 @@ bookdown_to_book_txt = function(
   rm(list = c("full_file", "index"))
 
   path = bookdown_path(path)
-  #owd = getwd()
-  #setwd(path)
-  #on.exit({
-  # setwd(owd)
-  #})
+  
   rmd_regex = "[.][R|r]md$"
   rmd_files = bookdown_rmd_files(path = path)
   md_files = sub(rmd_regex, ".md", rmd_files, ignore.case = TRUE)


### PR DESCRIPTION
The setwd() bits are throwing off the `leanbuild::bookdown_to_leanpub()` function when I attempt to call it from outside of R like: 
```
Rscript -e "leanbuild::bookdown_to_leanpub()" 
```
This makes this error: 
```
Error in bookdown::render_book(input = input, output_format = output_format) : 
  object 'input' not found
Calls: <Anonymous> -> <Anonymous> -> <Anonymous> -> resolve -> basename
Error in setwd(owd) : object 'owd' not found
```
An example: https://github.com/jhudsl/ITCR_Documentation_and_Usability_Leanpub/runs/3423258226?check_suite_focus=true

It doesn't appear to be serving a function and `setwd()` is dicey sometimes anyway so I tried deleting it and running the command without it and it works fine. 

I may find out later why this chunk was needed but I guess I'll cross that bridge when I come to it. 