### PR TITLE
Footnote conversion added

### DIFF
--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -281,7 +281,7 @@ convert_footnotes <- function(content) {
     content <- content[-find_any_middle_lines]
     
     #### Append footnotes to the end of the file
-    content <- append(content, footnotes)
+    content <- append(content, c("\n", footnotes))
     }
   return(content)
 }

--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -228,16 +228,21 @@ add_footer <- function(rmd_path, footer_text = NULL) {
   )
 }
 
+#' Convert Bookdown footnotes to Leanpub-formatted footnotes
+#'
+#' @param content a character vector containing the lines of content from a file read in with readLines()
+#'
+#' @return a character vector containing the content given but with Leanpub formatted foonotes 
+#' @export
+#' @rdname footnotes
+#' 
 convert_footnotes <- function(content) {
   
   # For a vector of content read in, look for Bookdown-formatted footnotes and format them as Leanpub wants them
   start_footnote_indices <- grep("\\^\\[", content)
 
   # Don't bother if there are no footnotes
-  if(is.null(start_footnote_indices)) {
-    rm(content) 
-    break
-  }
+  if(length(start_footnote_indices) > 0) {
   
   # Replace start of footnote notation with Leanpub friendly format
   
@@ -256,7 +261,7 @@ convert_footnotes <- function(content) {
   content[end_footnote_indices] <- stringr::str_remove(content[end_footnote_indices], "\\]$")
   
   content <- R.utils::insert(content, end_footnote_indices + 1, "{\\aside}")
-  
+  } 
   return(content)
 }
 

--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -260,7 +260,7 @@ convert_footnotes <- function(content) {
   # Now replace end of footnote notation
   content[end_footnote_indices] <- stringr::str_remove(content[end_footnote_indices], "\\]$")
   
-  content <- R.utils::insert(content, end_footnote_indices + 1, "{\\aside}")
+  content <- R.utils::insert(content, end_footnote_indices + 1, "{/aside}")
   } 
   return(content)
 }

--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -218,12 +218,68 @@ download_png_urls <- function(urls) {
 
 
 add_footer <- function(rmd_path, footer_text = NULL) {
-  
   if (is.null(footer_text)) {
     stop("Need character string in footer_text argument to append to end of file.")
   }
+
+  write(as.character(footer_text),
+    file = rmd_path,
+    append = TRUE
+  )
+}
+
+convert_footnotes <- function(content) {
   
-  write(as.character(footer_text), 
-        file = rmd_path, 
-        append = TRUE)
+  # For a vector of content read in, look for Bookdown-formatted footnotes and format them as Leanpub wants them
+  start_footnote_indices <- grep("\\^\\[", content)
+
+  # Don't bother if there are no footnotes
+  if(is.null(start_footnote_indices)) {
+    rm(content) 
+    break
+  }
+            
+  # Find the line which the footnote ends at
+  end_footnote_indices <- sapply(start_footnote_indices,
+                                 find_end_of_footnote,
+                                 content = content)
+
+  # Replace footnote notation with Leanpub friendly format
+  
+  # Remove Bookdown start footnote notation
+  content[start_footnote_indices] <- stringr::str_remove(content[start_footnote_indices], "\\^\\[")
+  
+  # Insert footnote starting tag for Leanpub
+  content <- R.utils::insert(content, start_footnote_indices, "{aside}")
+  
+  # Repeat same steps for end of footnote notation
+  content[end_footnote_indices] <- stringr::str_remove(content[end_footnote_indices], "\\]")
+  
+  content <- R.utils::insert(content, end_footnote_indices, "{\\aside}")
+  
+  return(content)
+}
+
+# Given an index of the start of a footnote, find the end of it.
+find_end_of_footnote <- function(start_footnote_index, content) {
+
+  # See if the end of the footnote is in the same line
+  end_bracket <- grepl("\\]", content[start_footnote_index])
+
+  # Keep looking in each next line until we find it.
+  if (end_bracket == FALSE) {
+    footnote_index <- start_footnote_index
+    while (end_bracket == FALSE) {
+      # Add one
+      footnote_index <- footnote_index + 1
+
+      # Look in next line
+      end_bracket <- grepl("*\\]", content[footnote_index])
+
+      if (footnote_index == length(content) && end_bracket == FALSE) {
+        stop(paste("Searched end of file and could not find end of footnote:", content[start_footnote_index]))
+      }
+    }
+    return(footnote_index)
+  }
 }

--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -256,7 +256,7 @@ convert_footnotes <- function(content) {
     footnote_number <- 1:length(start_footnote_indices)
     
     # Build the footnotenotation we will replace the `^[` with
-    footnote_tag <- paste0("[^note ", footnote_number, "]")
+    footnote_tag <- paste0("[^note", footnote_number, "]")
     
     # Collapse multiline footnotes: 
     footnotes <- paste0(trimws(content[start_footnote_indices:end_footnote_indices]), collapse = " ")

--- a/R/aaa_utils.R
+++ b/R/aaa_utils.R
@@ -232,36 +232,41 @@ add_footer <- function(rmd_path, footer_text = NULL) {
 #'
 #' @param content a character vector containing the lines of content from a file read in with readLines()
 #'
-#' @return a character vector containing the content given but with Leanpub formatted foonotes 
+#' @return a character vector containing the content given but with Leanpub formatted foonotes
 #' @export
 #' @rdname footnotes
-#' 
+#'
 convert_footnotes <- function(content) {
-  
+
   # For a vector of content read in, look for Bookdown-formatted footnotes and format them as Leanpub wants them
   start_footnote_indices <- grep("\\^\\[", content)
 
   # Don't bother if there are no footnotes
-  if(length(start_footnote_indices) > 0) {
-  
-  # Replace start of footnote notation with Leanpub friendly format
-  
-  # Remove Bookdown start footnote notation
-  content[start_footnote_indices] <- stringr::str_remove(content[start_footnote_indices], "\\^\\[")
-  
-  # Insert footnote starting tag for Leanpub
-  content <- R.utils::insert(content, start_footnote_indices, "{aside}")
-  
-  # Find the line which the footnote ends at
-  end_footnote_indices <- sapply(start_footnote_indices,
-                                 find_end_of_footnote,
-                                 content = content)
-  
-  # Now replace end of footnote notation
-  content[end_footnote_indices] <- stringr::str_remove(content[end_footnote_indices], "\\]$")
-  
-  content <- R.utils::insert(content, end_footnote_indices + 1, "{/aside}")
-  } 
+  if (length(start_footnote_indices) > 0) {
+
+    # Replace start of footnote notation with Leanpub friendly format
+
+    # Remove Bookdown start footnote notation
+    content[start_footnote_indices] <- stringr::str_replace(content[start_footnote_indices], "\\^\\[", "[^note]: ")
+
+    # Find the line which the footnote ends at
+    end_footnote_indices <- sapply(start_footnote_indices,
+      find_end_of_footnote,
+      content = content
+    )
+
+    # Go through each footnote's indices
+    for (index in 1:length(start_footnote_indices)) {
+
+      # If the footnote is not on one line
+      if (start_footnote_indices[index] != end_footnote_indices[index]) {
+
+        # If footnote is not all in one line, the rest has to be indented
+        # BUT exclude the first line - hence the + 1
+        content[(start_footnote_indices[index] + 1):end_footnote_indices[index]] <- paste0("    ", content[(start_footnote_indices[index] + 1):end_footnote_indices[index]])
+      }
+    }
+  }
   return(content)
 }
 

--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -297,7 +297,7 @@ bookdown_to_leanpub <- function(path = ".",
       remove_resources_start = remove_resources_start,
       footer_text = footer_text
     )
-
+    
     if (length(bib_files) > 0) {
       if (verbose > 1) {
         message("Making references for ", file)

--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -50,10 +50,6 @@ bookdown_file <- function(path = ".") {
   return(file_path)
 }
 
-regex <- switch(type,
-                rmd = "[.][R|r]md$",
-                md = "[.]md$")
-
 #' Look for bookdown file paths
 #'
 #' @param path  Where to look for the _bookdown.yml file. Passes to get_bookdown_spec() function. By default looks in current directory
@@ -62,7 +58,10 @@ regex <- switch(type,
 #' @return The file paths to Rmds listed in the _bookdown.yml file. 
 #' @export
 #' 
-find_bookdown_files <- function(path = ".", type = "rmd") {
+find_bookdown_files <- function(path = ".", 
+                                type = "rmd") {
+  
+  type <- match.arg(type, choices = c("rmd", "bib"))
   
   # Declare regex depending on file type
   regex <- switch(type,
@@ -80,13 +79,15 @@ find_bookdown_files <- function(path = ".", type = "rmd") {
   # Only keep Rmd files
   files <- grep(regex, files, value = TRUE)
   
+  # Get root_dir
+  root_dir <- bookdown_path(path = path)
+  
   # If there's no files listed, print a warning and try to find them
   if (is.null(files) || all(is.na(files)) || length(files) == 0) {
     warning(
-      "_bookdown.yml does not list ", type, " files. Will look for ", type, " files in ", 
-      root_dir
+      paste("_bookdown.yml does not list ", type, " files. Will look for ", type, " files in ", 
+      root_dir)
     )
-    root_dir <- bookdown_path(path = path)
     
     # Try to find Rmd files in the root_dir
     files <- list.files(
@@ -223,7 +224,7 @@ bookdown_to_leanpub <- function(path = ".",
   path <- bookdown_path(path)
   
   if (verbose) {
-    message(paste0("Looking for bookdown file in ", path))
+    message(paste0("Looking for bookdown files in ", path))
   }
   rmd_files <- find_bookdown_files(path = path, type = "rmd")
   
@@ -391,9 +392,9 @@ bookdown_to_book_txt <- function(path = ".",
   
   # need to fix about quiz
   writeLines(df$file, book_txt)
-  L <- list(
+  output_list <- list(
     md_order = df,
     book_file = book_txt
   )
-  return(L)
+  return(output_list)
 }

--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -137,15 +137,14 @@ copy_resources <- function(path = ".",
   # Assume image directory is `resources/images`
   res_image_dir <- file.path(path, images_dir )
   
-  # Create the directory if it doesn't exist
+  # Creat the directory if it doesn't exist
   dir.create(res_image_dir, showWarnings = FALSE, recursive = TRUE)
   
-  manuscript_image_dir <- file.path(output_dir, images_dir)
+  manuscript_image_dir <- file.path(output_dir, images_dir )
   
   dir.create(manuscript_image_dir, showWarnings = FALSE, recursive = TRUE)
   
   manuscript_image_dir <- normalizePath(manuscript_image_dir)
-  
   if (file.exists(res_image_dir)) {
     copy_directory_contents(res_image_dir, manuscript_image_dir)
   }
@@ -171,8 +170,7 @@ copy_bib <- function(path = ".", output_dir = "manuscript") {
 #'
 #' @param path path to the bookdown book, must have a `_bookdown.yml` file
 #' @param output_dir output directory to put files.  It should likely be
-#' relative to path.
-#' @param output_dir directory where referenced images are sent. Default is 'resources/images'.
+#' relative to path
 #' @param render if `TRUE`, then [bookdown::render_book()] will be run on each Rmd.
 #' @param verbose print diagnostic messages
 #' @param remove_resources_start remove the word `resources/` at the front
@@ -188,7 +186,6 @@ copy_bib <- function(path = ".", output_dir = "manuscript") {
 bookdown_to_leanpub <- function(path = ".",
                                 render = TRUE,
                                 output_dir = "manuscript",
-                                images_path = file.path("resources", "images"),
                                 make_book_txt = FALSE,
                                 remove_resources_start = FALSE,
                                 verbose = TRUE, 
@@ -216,21 +213,18 @@ bookdown_to_leanpub <- function(path = ".",
     # Get the index file path
     index_file <- grep("index", rmd_files, ignore.case = TRUE, value = TRUE)
     
-    # Norma
     index_file <- normalizePath(index_file)
     
     if (length(index_file) == 0 || is.na(index_file)) {
       index_file <- rmd_files[1]
     }
+    message(paste("index_file is", index_file))
     
-    # Set citeproc for references
     output_format <- bookdown::gitbook(pandoc_args = "--citeproc")
+    # output_format$pandoc$to = output_format$pandoc$from
     output_format$pandoc$args <- c(output_format$pandoc$args, "--citeproc")
-    
-    # Render bookdown
     bookdown::render_book(input = index_file, 
                           output_format = output_format, 
-                          # If this is not false then this fails if ran from terminal
                           clean_envir = FALSE)
   }
 
@@ -238,13 +232,11 @@ bookdown_to_leanpub <- function(path = ".",
   if (verbose) {
     message("Copying Resources")
   }
-  copy_docs(images_path, output_dir = output_dir)
-  
+  copy_resources(path, output_dir = output_dir)
   if (verbose) {
     message("Copying Docs folder")
   }
   copy_docs(path, output_dir = output_dir)
-  
   if (verbose) {
     message("Copying bib files")
   }
@@ -252,15 +244,15 @@ bookdown_to_leanpub <- function(path = ".",
   # FIXME Can also use bookdown_rmd_files
   # rmd_files = list.files(pattern = rmd_regex)
 
+
   bib_files <- list.files(pattern = "[.]bib$")
-  
   if (length(bib_files) > 0) {
     pandoc_args <- paste0("--bibliography=", path.expand(normalizePath(bib_files)))
   } else {
     pandoc_args <- NULL
   }
-  
-  
+
+  # run_env = new.env()
   md_files <- sub(rmd_regex, ".md", rmd_files, ignore.case = TRUE)
   md_files <- file.path(output_dir, basename(md_files))
 
@@ -287,7 +279,6 @@ bookdown_to_leanpub <- function(path = ".",
     }
   }
   out <- NULL
-  
   if (make_book_txt) {
     if (verbose > 1) {
       message("Running bookdown_to_book_txt")
@@ -298,17 +289,16 @@ bookdown_to_leanpub <- function(path = ".",
       verbose = verbose
     )
   }
-  out_files <- list(
+  L <- list(
     output_files = md_files,
     full_output_files = normalizePath(md_files, winslash = "/")
   )
-  out_files$book_txt_output <- out
-  
-  return(out_files)
+  L$book_txt_output <- out
+  return(L)
 }
 
 
-#' Create a `Book.txt` in the output directory
+#' Convert Bookdown to Leanpub
 #'
 #' @param path path to the bookdown book, must have a `_bookdown.yml` file
 #' @param output_dir output directory to put files.  It should likely be
@@ -317,30 +307,24 @@ bookdown_to_leanpub <- function(path = ".",
 #'
 #' @return A list of output files in order, the book text file name, and diagnostics
 #' @export
-#' 
-bookdown_to_book_txt <- function(path = ".",
+bookdown_to_book_txt <- function(
+                                 path = ".",
                                  output_dir = "manuscript",
                                  verbose = TRUE) {
   index <- full_file <- NULL
-  
   rm(list = c("full_file", "index"))
 
   path <- bookdown_path(path)
 
   rmd_regex <- "[.][R|r]md$"
-  
   rmd_files <- bookdown_rmd_files(path = path)
-  
   md_files <- sub(rmd_regex, ".md", rmd_files, ignore.case = TRUE)
-  
   md_df <- tibble::tibble(
     file = md_files,
     index = seq_along(md_files)
   )
-  
   quiz_files <- paste0("quiz-", md_files)
   bad_quiz_files <- paste0("quiz_", md_files)
-  
   if (any(file.exists(file.path(output_dir, bad_quiz_files)))) {
     warning(
       "Naming convention for quizzes is quiz-, not quiz_",
@@ -356,24 +340,21 @@ bookdown_to_book_txt <- function(path = ".",
     file = bad_quiz_files,
     index = seq_along(bad_quiz_files) + 0.5
   )
-  
   quiz_df <- dplyr::bind_rows(quiz_df, bad_quiz_df)
   rm(list = c("bad_quiz_files", "bad_quiz_df"))
-  
   quiz_df <- quiz_df %>%
     dplyr::arrange(index)
-  
   df <- dplyr::bind_rows(md_df, quiz_df)
-  
   rm(list = c("quiz_df"))
 
   df <- df %>%
-    dplyr::arrange(index) %>%
-    dplyr::mutate(full_file = file.path(output_dir, file)) %>%
+    dplyr::arrange(index)
+  df <- df %>%
+    dplyr::mutate(full_file = file.path(output_dir, file))
+  df <- df %>%
     dplyr::filter(file.exists(full_file))
 
   book_txt <- file.path(output_dir, "Book.txt")
-  
   # need to fix about quiz
   writeLines(df$file, book_txt)
   L <- list(

--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -50,35 +50,57 @@ bookdown_file <- function(path = ".") {
   return(file_path)
 }
 
-#' Get file paths all Rmds in the bookdown directory
+regex <- switch(type,
+                rmd = "[.][R|r]md$",
+                md = "[.]md$")
+
+#' Look for bookdown file paths
 #'
-#' @param path  Where to look for the _bookdown.yml file. Passes toget_bookdown_spec() function. By default looks in current directory
-#'
+#' @param path  Where to look for the _bookdown.yml file. Passes to get_bookdown_spec() function. By default looks in current directory
+#' @param type What type of file to extract the list of files for. Either "rmd" or "bib". Default is "rmd".
+#' 
 #' @return The file paths to Rmds listed in the _bookdown.yml file. 
 #' @export
 #' 
-bookdown_rmd_files <- function(path = ".") {
+find_bookdown_files <- function(path = ".", type = "rmd") {
   
+  # Declare regex depending on file type
+  regex <- switch(type,
+                  rmd = "[.][R|r]md$",
+                  bib = "[.]bib$")
+  
+  # Read in _bookdown.yml
   spec <- get_bookdown_spec(path)
   
-  files <- spec$rmd_files
+  # Extract file list
+  files <- switch(type,
+                  rmd = spec$rmd_files,
+                  bib = spec$bibliography)
+  
+  # Only keep Rmd files
+  files <- grep(regex, files, value = TRUE)
+  
+  # If there's no files listed, print a warning and try to find them
   if (is.null(files) || all(is.na(files)) || length(files) == 0) {
     warning(
-      "No bookdown specification of the files, using ",
-      "list.files(pattern ='.Rmd')"
+      "_bookdown.yml does not list ", type, " files. Will look for ", type, " files in ", 
+      root_dir
     )
     root_dir <- bookdown_path(path = path)
+    
+    # Try to find Rmd files in the root_dir
     files <- list.files(
-      pattern = "[.]Rmd", ignore.case = TRUE,
+      pattern = regex, ignore.case = TRUE,
       path = root_dir, full.names = FALSE
     )
   }
+  
   return(files)
 }
 
 #' Declare file path to docs/ folder
 #'
-#' @param path  Where to look for the _bookdown.yml file. Passes toget_bookdown_spec() function. By default looks in current directory
+#' @param path  Where to look for the _bookdown.yml file. Passes to get_bookdown_spec() function. By default looks in current directory
 #'
 #' @return The file paths to Rmds listed in the _bookdown.yml file. 
 #' @export
@@ -203,7 +225,7 @@ bookdown_to_leanpub <- function(path = ".",
   if (verbose) {
     message(paste0("Looking for bookdown file in ", path))
   }
-  rmd_files <- bookdown_rmd_files(path = path)
+  rmd_files <- find_bookdown_files(path = path, type = "rmd")
   
   if (verbose) {
     message(paste0(c("Processing these files: ", rmd_files), collapse = "\n"))
@@ -249,10 +271,8 @@ bookdown_to_leanpub <- function(path = ".",
     message("Copying bib files")
   }
   copy_bib(path, output_dir = output_dir)
-  # FIXME Can also use bookdown_rmd_files
-  # rmd_files = list.files(pattern = rmd_regex)
-
-  bib_files <- list.files(pattern = "[.]bib$")
+  
+  bib_files <- find_bookdown_files(path = path, type = "bib")
   
   if (length(bib_files) > 0) {
     pandoc_args <- paste0("--bibliography=", path.expand(normalizePath(bib_files)))
@@ -321,17 +341,12 @@ bookdown_to_leanpub <- function(path = ".",
 bookdown_to_book_txt <- function(path = ".",
                                  output_dir = "manuscript",
                                  verbose = TRUE) {
-  index <- full_file <- NULL
-  
-  rm(list = c("full_file", "index"))
-
+  # Get path to _bookdown.yml
   path <- bookdown_path(path)
-
-  rmd_regex <- "[.][R|r]md$"
   
-  rmd_files <- bookdown_rmd_files(path = path)
+  rmd_files <- find_bookdown_files(path = path, type = "rmd")
   
-  md_files <- sub(rmd_regex, ".md", rmd_files, ignore.case = TRUE)
+  new_md_filenames <- sub(rmd_regex, ".md", rmd_files, ignore.case = TRUE)
   
   md_df <- tibble::tibble(
     file = md_files,

--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -50,6 +50,10 @@ bookdown_file <- function(path = ".") {
   return(file_path)
 }
 
+regex <- switch(type,
+                rmd = "[.][R|r]md$",
+                md = "[.]md$")
+
 #' Look for bookdown file paths
 #'
 #' @param path  Where to look for the _bookdown.yml file. Passes to get_bookdown_spec() function. By default looks in current directory
@@ -58,10 +62,7 @@ bookdown_file <- function(path = ".") {
 #' @return The file paths to Rmds listed in the _bookdown.yml file. 
 #' @export
 #' 
-find_bookdown_files <- function(path = ".", 
-                                type = "rmd") {
-  
-  type <- match.arg(type, choices = c("rmd", "bib"))
+find_bookdown_files <- function(path = ".", type = "rmd") {
   
   # Declare regex depending on file type
   regex <- switch(type,
@@ -79,15 +80,13 @@ find_bookdown_files <- function(path = ".",
   # Only keep Rmd files
   files <- grep(regex, files, value = TRUE)
   
-  # Get root_dir
-  root_dir <- bookdown_path(path = path)
-  
   # If there's no files listed, print a warning and try to find them
   if (is.null(files) || all(is.na(files)) || length(files) == 0) {
     warning(
-      paste("_bookdown.yml does not list ", type, " files. Will look for ", type, " files in ", 
-      root_dir)
+      "_bookdown.yml does not list ", type, " files. Will look for ", type, " files in ", 
+      root_dir
     )
+    root_dir <- bookdown_path(path = path)
     
     # Try to find Rmd files in the root_dir
     files <- list.files(
@@ -224,7 +223,7 @@ bookdown_to_leanpub <- function(path = ".",
   path <- bookdown_path(path)
   
   if (verbose) {
-    message(paste0("Looking for bookdown files in ", path))
+    message(paste0("Looking for bookdown file in ", path))
   }
   rmd_files <- find_bookdown_files(path = path, type = "rmd")
   
@@ -392,9 +391,9 @@ bookdown_to_book_txt <- function(path = ".",
   
   # need to fix about quiz
   writeLines(df$file, book_txt)
-  output_list <- list(
+  L <- list(
     md_order = df,
     book_file = book_txt
   )
-  return(output_list)
+  return(L)
 }

--- a/R/gs_png.R
+++ b/R/gs_png.R
@@ -60,6 +60,7 @@ gs_png_download <- function(url, output_dir = ".", overwrite = TRUE) {
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
   outfile <- file.path(output_dir, paste0(id, "_", slide_id, ".png"))
   if (!file.exists(outfile) || overwrite) {
+    message(paste("downloading slide png:", slide_id, " to ", outfile))
     curl::curl_download(url, destfile = outfile, quiet = FALSE)
   }
   stopifnot(file.exists(outfile))

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -114,7 +114,8 @@ parse_quiz <- function(quiz_path) {
       meta = find_metadata(x),
       number = ifelse(number == "", NA, number),
       repeated = duplicated(number) & !is.na(number)
-    )
+    ))
+  
   df <- df %>%
     dplyr::select(-number)
   types <- df %>%

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -81,25 +81,21 @@ extract_meta <- function(x) {
 #' )
 #' out <- parse_quiz(x)
 #' check_quiz_attributes(out)
-parse_quiz <- function(quiz_path) {
-  
-  # Read in quiz
-  if (length(quiz_path) == 1 && file.exists(quiz_path)) {
-    quiz_content <- readLines(quiz_path, warn = FALSE)
+parse_quiz <- function(x) {
+  if (length(x) == 1 && file.exists(x)) {
+    x <- readLines(x, warn = FALSE)
   }
-
   answer <- meta <- repeated <- question <- number <- NULL
   rm(list = c("number", "question", "repeated", "answer", "meta"))
 
-  quiz_df <- extract_quiz(quiz_content)
+  df <- extract_quiz(x)
 
 
-  if (length(quiz_df) == 0) {
+  if (length(df) == 0) {
     return(NULL)
   }
-  stopifnot(length(quiz_df) >= 2)
-  
-  quiz_meta <- quiz_df[1]
+  stopifnot(length(df) >= 2)
+  quiz_meta <- df[1]
   full_quiz_spec <- quiz_meta
   quiz_meta <- sub("\\{\\s*quiz(,|)", "{", quiz_meta)
 

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -115,7 +115,7 @@ parse_quiz <- function(quiz_path) {
     dplyr::mutate(
       question = find_question(trimmed),
       answer = find_answer(trimmed),
-      number = etrimmedtract_number(trimmed),
+      number = extract_number(trimmed),
       meta = find_metadata(trimmed),
       number = ifelse(number == "", NA, number),
       repeated = duplicated(number) & !is.na(number)

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -93,6 +93,7 @@ parse_quiz <- function(quiz_path) {
 
   quiz_df <- extract_quiz(quiz_content)
 
+
   if (length(quiz_df) == 0) {
     return(NULL)
   }
@@ -102,21 +103,21 @@ parse_quiz <- function(quiz_path) {
   full_quiz_spec <- quiz_meta
   quiz_meta <- sub("\\{\\s*quiz(,|)", "{", quiz_meta)
 
-  # remove the "/quiz" at the end of the file
-  quiz_df <- quiz_df[2:(length(quiz_df) - 1)]
-  
-  
-  quiz_df <- tibble::tibble(
-    original = quiz_df,
-    trimmed = trimws(quiz_df, which = "left"),
-    index = 1:length(quiz_df)
+  # remove the "/quiz"
+  df <- df[2:(length(df) - 1)]
+  df <- tibble::tibble(
+    original = df,
+    x = trimws(df, which = "left"),
+    index = 1:length(df)
   )
-  quiz_df <- quiz_df %>%
+  # df = df %>%
+  # dplyr::filter(!x %in% "")
+  df <- df %>%
     dplyr::mutate(
-      question = find_question(trimmed),
-      answer = find_answer(trimmed),
-      number = extract_number(trimmed),
-      meta = find_metadata(trimmed),
+      question = find_question(x),
+      answer = find_answer(x),
+      number = extract_number(x),
+      meta = find_metadata(x),
       number = ifelse(number == "", NA, number),
       repeated = duplicated(number) & !is.na(number)
     ) %>%

--- a/R/quiz.R
+++ b/R/quiz.R
@@ -81,21 +81,24 @@ extract_meta <- function(x) {
 #' )
 #' out <- parse_quiz(x)
 #' check_quiz_attributes(out)
-parse_quiz <- function(x) {
-  if (length(x) == 1 && file.exists(x)) {
-    x <- readLines(x, warn = FALSE)
+parse_quiz <- function(quiz_path) {
+  
+  if (length(quiz_path) == 1 && file.exists(quiz_path)) {
+    quiz_content <- readLines(quiz_path, warn = FALSE)
   }
+  
   answer <- meta <- repeated <- question <- number <- NULL
   rm(list = c("number", "question", "repeated", "answer", "meta"))
 
-  df <- extract_quiz(x)
+  quiz_df <- extract_quiz(quiz_content)
 
 
-  if (length(df) == 0) {
+  if (length(quiz_df) == 0) {
     return(NULL)
   }
-  stopifnot(length(df) >= 2)
-  quiz_meta <- df[1]
+  stopifnot(length(quiz_df) >= 2)
+  
+  quiz_meta <- quiz_df[1]
   full_quiz_spec <- quiz_meta
   quiz_meta <- sub("\\{\\s*quiz(,|)", "{", quiz_meta)
 

--- a/R/replace_html.R
+++ b/R/replace_html.R
@@ -479,6 +479,10 @@ replace_single_html <- function(file,
     element = "iframe", fullbleed = fullbleed,
     remove_resources_start = remove_resources_start
   )
+  if (verbose) {
+    message("Convert footnotes")
+  }
+  x <- convert_footnotes(x)
   
   # need to actually do changes
   writeLines(x, con = file)


### PR DESCRIPTION
This is working well! I added two functions which do the work and I incorporated it to run with the `bookdown_to_leanpub()` function. 

The footnote looks like: 
![Screen Shot 2021-08-30 at 12 21 57 PM](https://user-images.githubusercontent.com/23458084/131371685-692d9639-7396-4ed5-83fc-47be7d3cac4f.png)

Which links you to a page like this: 
![Screen Shot 2021-08-30 at 12 22 12 PM](https://user-images.githubusercontent.com/23458084/131371693-f26a1f3c-b23a-4aa4-b5a8-0bf5c4aa96fc.png)

I think we may find we need to adjust this as it is used. I mainly made this for my use case while trying to write it guessing about other use cases but ¯\_(ツ)_/¯