### PR TITLE
Try to fix GHA for filing PRs with leanbuild updates

### DIFF
--- a/.github/workflows/update-leanpub.yml
+++ b/.github/workflows/update-leanpub.yml
@@ -1,7 +1,7 @@
 
 # Adapted for this jhudsl repository by Candace Savonen Aug 2021
 
-name: Render and publish Leanpub
+name: Update Leanpub Upon Merge
 
 # Triggers the workflow AFTER changes to leanbuild have been merged
 on:
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install  -y --no-install-recommends subversion
 
           # Copy over the latest leanbuild build
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_HEAD_REF} leanbuild/
+          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/master leanbuild/
 
       # Run leanpub rendering
       - name: Run leanbuild::bookdown_to_leanpub
@@ -51,7 +51,7 @@ jobs:
           body: |
             ### Description:
              This PR has changes to this repository's files using the latest leanbuild package changes!
-             If they don't look right, file an issue on the leanbuild package: https://github.com/jhudsl/leanbuild/issuesand do not merge. 
+             If they don't look right, file an issue on the leanbuild package: https://github.com/jhudsl/leanbuild/issuesand do not merge.
           labels: |
             automated
           reviewers: $GITHUB_ACTOR

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(person(given = "John",family = "Muschelli",
   email = "cansav09@gmail.com",
   role = c("aut", "cre"),
   comment = c(ORCID = "0000-0001-6331-7070")), 
-  person(given = "Carrie",family = "Wright",
+  person(given = "Carrie", family = "Wright",
   email = "cwrigh60@jhu.edu",
   role = c("ctb"))
   )
@@ -52,6 +52,6 @@ Remotes:
 ByteCompile: true
 Type: Package
 VignetteBuilder: knitr
-URL: https://github.com/muschellij2/didactr
-BugReports: https://github.com/muschellij2/didactr/issues
+URL: https://github.com/jhudsl/leanbuild
+BugReports: https://github.comjhudsl/leanbuild/issues
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Leverages the 'bookdown' package and other tools to create courses
   that can be hosted on Leanpub.
 Authors@R: c(person(given = "John",family = "Muschelli",
   email = "muschellij2@gmail.com",
-  role = c("aut", "cre"),
+  role = c("aut"),
   comment = c(ORCID = "0000-0001-6469-1750")),
   person(given = "Candace",family = "Savonen",
   email = "cansav09@gmail.com",


### PR DESCRIPTION
The GITHUB_REF variable is different if something is triggered by a PR or a merge. I copied the code for the PR triggered one to create this merging triggered one and that's why its broken (I'm pretty sure). 

It can't find the leanbuild folder I have it copy because GITHUB_REF is wrong and hence the url is wrong. 

Unfortunately I will need to merge this to test if it actually fixes it. 


