### PR TITLE
Add toc_close.css download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ License: GPL-3
 Imports: googledrive,
     dplyr,
     httr,
-    didactr,
     fs,
     jsonlite,
     utils,

--- a/R/coursera.R
+++ b/R/coursera.R
@@ -228,6 +228,11 @@ render_coursera <- function(
   ###### Declare all the file paths relative to root directory ######
   # Input files:
   toc_close_css <- file.path(root_dir, "assets", "toc_close.css")
+
+  if (!file.exists(toc_close_css)) {
+    download.file("https://raw.githubusercontent.com/jhudsl/leanbuild/master/inst/extdata/toc_close.css",
+                  destfile = toc_close_css)
+  }
   output_yaml_file <- file.path(root_dir, output_yaml)
 
   # Output files:


### PR DESCRIPTION
Closes #53 Just downloads the toc_close.css file if it doesn't exist. This file should be the same no matter what so makes sense to just add it to extData and have it download if its needed. 