### PR TITLE
Citeproc Strikes Back: Add warning and fix syntax

### DIFF
--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -208,10 +208,11 @@ bookdown_to_leanpub <- function(path = ".",
     }
     message(paste("index_file is", index_file))
 
-    if (rmarkdown::pandoc_version() > 2.11) {
+    if (rmarkdown::pandoc_version() >= "2.11") {
       output_format <- bookdown::gitbook(pandoc_args = "--citeproc")
       output_format$pandoc$args <- c(output_format$pandoc$args, "--citeproc")
     } else {
+      warning("Pandoc version is not greater than 2.11 so citations will not be able to be rendered properly")
       output_format = NULL
     }
     bookdown::render_book(


### PR DESCRIPTION
Background issues to this ongoing problem: #7 and #48 

Basically you need a certain version of pandoc (greater than 2.11) to render citations properly. If you don't have greater than that before leanbuild would just break. Now I just have it give you a warning that the citations won't build but it will continue. 

Also had my logic had the syntax incorrect so I had to fix that so that the question would be asked properly. Didn't realize in this particular instance numbers aren't actually treated like numbers in R. rmarkdown::pandoc_version() gives you a  `numeric_version` which is different than a number. TIL. 
