### PR TITLE
I think this will remove the periods we need to get rid of

### DIFF
--- a/R/replace_html.R
+++ b/R/replace_html.R
@@ -298,17 +298,17 @@ build_image <- function(src, ..., caption = NULL, embed = NULL,
   }
 
   # Default is to not use a !
-  link <- paste0("[", words, "](", myenv$src, ").")
+  link <- paste0("[", words, "](", myenv$src, ")")
 
   # But if its an image or video, use use !
   if (!is.null(element)) {
     if (element == "img") {
-      link <- paste0("![", words, "](", myenv$src, ").")
+      link <- paste0("![", words, "](", myenv$src, ")")
     }
   }
   if (!is.null(myenv$type)) {
     if (myenv$type == "video") {
-      link <- paste0("![", words, "](", myenv$src, ").")
+      link <- paste0("![", words, "](", myenv$src, ")")
     }
   }
 


### PR DESCRIPTION
To fix issues with:
1) images not being full size
2) videos not being centered
3) some images not being centered
4) an extra period after images/videos

I think changing the `).`  to `)` in the `paste0` functions for adding the links to videos and images in R/replace_html.R should fix this. 