### PR TITLE
Get rid of pesky comma on image specs

### DIFF
--- a/R/replace_html.R
+++ b/R/replace_html.R
@@ -246,7 +246,7 @@ build_image <- function(src, ..., caption = NULL, embed = NULL,
     'align: "{align}",',
     'type: "{type}",',
     'poster: "{poster}",',
-    'embed: "{embed}"'
+    'embed: "{embed}",'
   )
   if (is.null(fullbleed) ||
     length(fullbleed) == 0 ||
@@ -272,6 +272,8 @@ build_image <- function(src, ..., caption = NULL, embed = NULL,
 
   # Make sure it's coerced as a character
   specs <- unlist(sapply(specs, as.character))
+
+  specs <- gsub(",\\}$", "\\}", specs)
 
   # Set as fullbleed if TRUE
   specs <- c(specs, if (fullbleed) "fullbleed: true")

--- a/R/replace_html.R
+++ b/R/replace_html.R
@@ -273,7 +273,7 @@ build_image <- function(src, ..., caption = NULL, embed = NULL,
   # Make sure it's coerced as a character
   specs <- unlist(sapply(specs, as.character))
 
-  specs <- gsub(",\\}$", "\\}", specs)
+  specs <- gsub(",\\}$", "}", specs)
 
   # Set as fullbleed if TRUE
   specs <- c(specs, if (fullbleed) "fullbleed: true")


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
This should close #63 

Is it the most elegant solution? No. But it works and it's simple.