### PR TITLE
Fix bookdown_to_book_txt

### DIFF
--- a/R/bookdown_to_leanpub.R
+++ b/R/bookdown_to_leanpub.R
@@ -401,7 +401,8 @@ bookdown_to_book_txt <- function(path = ".",
         lower_filename == "about.rmd" ~ as.character(length(all_files)),
         TRUE ~ num
       ),
-      num = as.numeric(num)
+      num = as.numeric(num),
+      file_name = gsub(".Rmd$", ".md", file_name)
     ) %>%
     # Put quizzes in order!
     dplyr::arrange(num, file_type) %>%


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
There's a small glitch in the `bookdown_to_book_txt()` function. It wasn't replacing the `.Rmd` with the `.md` suffixes. This fix makes sure it does do that so that those files show up in Leanpub. 

